### PR TITLE
Remove references to "Roblox" from source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-![](./assets/luau-logo.png)
+<img src="./assets/luau-logo.png" width="128" align="right">
 
-# Luau language grammar for programming under the [Roblox Platform](https://devforum.roblox.com/).
+# Luau Language Grammar for highlight.js
 
-## [View the Luau language here](https://luau-lang.org/).
+[Luau](https://luau.org) is a fast, small, safe, gradually typed embeddable scripting language derived from Lua.
 
 [![NPM](https://nodei.co/npm/highlightjs-luau.png)](https://www.npmjs.com/package/highlightjs-luau)
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
 	},
 	"keywords": [
 		"Luau",
-		"Roblox",
 		"hljs",
 		"highlightjs",
 		"highlight.js"


### PR DESCRIPTION
Makes some small changes to the README layout, updates the URL to the Luau language website, and removes references to "Roblox". 

Closes #2.